### PR TITLE
Fix media extraction when img-back uses src instead of data-src

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -68,8 +68,16 @@ def extract_download_links(soup: BeautifulSoup) -> list[str]:
     image_items = soup.find_all("img", {"class": "img-back"})
     video_items = soup.find_all("source")
 
-    image_download_links = [image_item.get("data-src") for image_item in image_items]
+    image_download_links = [
+        image_item.get("data-src")
+        or image_item.get("src")
+        or image_item.get("data-lazy-src")
+        or image_item.get("data-cfsrc")
+        for image_item in image_items
+    ]
     video_download_links = [video_item.get("src") for video_item in video_items]
+    image_download_links = [link for link in image_download_links if link]
+    video_download_links = [link for link in video_download_links if link]
     return list({*image_download_links, *video_download_links})
 
 


### PR DESCRIPTION
## Summary
- fix album media extraction when `img.img-back` does not expose `data-src`
- add fallback chain for image URLs: `data-src`, `src`, `data-lazy-src`, `data-cfsrc`
- filter out empty links before de-duplication

## Why
Erome now serves some album images using `src` on `img.img-back`. The current logic reads only `data-src`, which causes missing URLs.

## Verification
- validated against `https://www.erome.com/a/owopX5pF`
- `extract_download_links` now returns 8 valid links with no `None` values
